### PR TITLE
zy/47 fix multiline issue

### DIFF
--- a/example/example_7.dart
+++ b/example/example_7.dart
@@ -1,0 +1,27 @@
+import 'dart:io';
+
+import 'package:rdflib/rdflib.dart';
+
+main() async {
+  String filePath = 'example/sample_ttl_6.ttl';
+  // Read file content to a local String.
+  String fileContents = await File(filePath).readAsStringSync();
+
+  print('-------Original file-------\n$fileContents');
+
+  // Create a graph to read turtle file and store info.
+  Graph g = Graph();
+
+  // Parse with the new method [Graph.parseTurtle] instead of [Graph.parse] (deprecated).
+  g.parseTurtle(fileContents);
+
+  // Serialize the Graph for output.
+  g.serialize(format: 'ttl', abbr: 'short');
+  print('-------Serialized String--------\n${g.serializedString}');
+
+  // Print out full format of triples (will use shorthand in serialization/export).
+  print('--------All triples in the graph-------');
+  for (Triple t in g.triples) {
+    print(t);
+  }
+}

--- a/example/sample_ttl_6.ttl
+++ b/example/sample_ttl_6.ttl
@@ -1,0 +1,14 @@
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix show: <http://example.org/vocab/show/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+show:218 rdfs:label "That Seventies Show"^^xsd:string .            
+show:218 rdfs:label "That Seventies Show"^^<http://www.w3.org/2001/XMLSchema#string> . 
+show:218 rdfs:label "That Seventies Show" .                                           
+show:218 show:localName "That Seventies Show"@en .                 
+show:218 show:localName 'Cette Série des Années Soixante-dix'@fr . 
+show:218 show:localName "Cette Série des Années Septante"@fr-be .  
+show:218 show:blurb '''This is a multi-line
+literal with many quotes (""""")
+and up to two sequential apostrophes ('').'''^^xsd:string .
+

--- a/lib/src/graph.dart
+++ b/lib/src/graph.dart
@@ -1135,8 +1135,9 @@ class Graph {
       // Process the multiline literal as needed.
       // Example: Replace line breaks with a special sequence.
 
-      String processedLiteral =
-          multilineLiteral.replaceAll(Platform.isWindows ? '\r\n' : '\n', ' ');
+      String processedLiteral = multilineLiteral.replaceAll(
+          Platform.isWindows ? '\r\n' : '\n',
+          Platform.isWindows ? r'\r\n' : r'\n');
 
       processedLiteral = processedLiteral.replaceAll('"', '\\"');
 

--- a/lib/src/graph.dart
+++ b/lib/src/graph.dart
@@ -2,6 +2,7 @@ import 'dart:convert';
 import 'dart:io' show File;
 
 import 'package:http/http.dart' as http;
+import 'package:universal_io/io.dart' show Platform;
 
 import './namespace.dart';
 import './term.dart';
@@ -1132,7 +1133,9 @@ class Graph {
 
       // Process the multiline literal as needed.
       // Example: Replace line breaks with a special sequence.
-      String processedLiteral = multilineLiteral.replaceAll('\n', '\\n');
+
+      String processedLiteral =
+          multilineLiteral.replaceAll(Platform.isWindows ? '\r\n' : '\n', ' ');
 
       processedLiteral = processedLiteral.replaceAll('"', '\\"');
 

--- a/lib/src/graph.dart
+++ b/lib/src/graph.dart
@@ -1119,7 +1119,9 @@ class Graph {
   String _preprocessTurtleContent(String turtleContent) {
     // Regular expression to match multiline literals.
 
-    final multilineLiteralRegex = RegExp(r'"""(.*?)"""', dotAll: true);
+    final multilineLiteralRegex = RegExp(
+        turtleContent.contains("'''") ? r"'''(.*?)'''" : r'"""(.*?)"""',
+        dotAll: true);
 
     // Replace each multiline literal with a processed version.
 
@@ -1131,6 +1133,8 @@ class Graph {
       // Process the multiline literal as needed.
       // Example: Replace line breaks with a special sequence.
       String processedLiteral = multilineLiteral.replaceAll('\n', '\\n');
+
+      processedLiteral = processedLiteral.replaceAll('"', '\\"');
 
       // Return the processed literal with the original triple quotes
       return '"$processedLiteral"';

--- a/lib/src/graph.dart
+++ b/lib/src/graph.dart
@@ -1152,7 +1152,7 @@ class Graph {
 
   /// Extract the language tag from a given literal
   String _getLangTag(String literal) {
-    return langTags.firstWhere((element) => literal.contains('@$element'));
+    return langTags.lastWhere((element) => literal.contains('@$element'));
   }
 
   /// Recursively combines all items in a list and its sub-items into a single string.

--- a/lib/src/graph.dart
+++ b/lib/src/graph.dart
@@ -409,7 +409,7 @@ class Graph {
   /// Parses whole text and update graph accordingly.
   @Deprecated('Use [Graph.parseTurtle] instead for parsing a turtle string')
   parseText(String text) {
-    List<String> lines = text.split('\n');
+    List<String> lines = text.split(Platform.isWindows ? '\r\n' : '\n');
     try {
       Map<String, dynamic> config = {
         'prefix': false,
@@ -700,7 +700,8 @@ class Graph {
         int line = int.parse(match.group(1)!);
         int column = int.parse(match.group(2)!);
 
-        List<String> lines = fileContent.split('\n');
+        List<String> lines =
+            fileContent.split(Platform.isWindows ? '\r\n' : '\n');
         String errorLine =
             lines.length >= line ? lines[line - 1] : "Unknown line";
 
@@ -746,7 +747,7 @@ class Graph {
   /// This is a helper method to aid in error reporting by providing the line number.
   int _findLineNumber(String content, List tripleList) {
     // Convert the content into lines
-    List<String> lines = content.split('\n');
+    List<String> lines = content.split(Platform.isWindows ? '\r\n' : '\n');
 
     // Convert the triple list back to a string to search for in the lines.
     String tripleString = tripleList.toString();
@@ -923,7 +924,7 @@ class Graph {
   void _writeGraphs(StringBuffer output, String indent) {
     String line = '';
     for (var k in graphs.keys) {
-      output.write('\n');
+      output.write(Platform.isWindows ? '\r\n' : '\n');
       bool isNewGraph = true;
       Set<Triple>? g = graphs[k];
       for (Triple t in g!) {
@@ -945,7 +946,7 @@ class Graph {
             line = '$firstHalf ${t.obj} ;';
           }
         } else {
-          line += '\n';
+          line += Platform.isWindows ? '\r\n' : '\n';
           String firstHalf = '$indent${_abbrUrirefToTtl(t.pre, contexts)}';
           if (t.obj.runtimeType == String) {
             line += '$firstHalf "${t.obj}" ;';
@@ -1038,7 +1039,7 @@ class Graph {
       }
     }
     // Add a new empty line before all the triples.
-    rtnStr += '\n';
+    rtnStr += Platform.isWindows ? '\r\n' : '\n';
     return rtnStr;
   }
 
@@ -1098,7 +1099,7 @@ class Graph {
   /// Current implementation is to match and replace line by line
   String _removeComments(String fileContent) {
     String rtnStr = '';
-    List<String> lines = fileContent.split('\n');
+    List<String> lines = fileContent.split(Platform.isWindows ? '\r\n' : '\n');
     for (var line in lines) {
       // See also: https://www.w3.org/TR/turtle/#sec-grammar-comments
       // comments in Turtle take the form of '#', outside an IRIREF or String,
@@ -1108,7 +1109,7 @@ class Graph {
         continue;
       }
       rtnStr += line.replaceAll(RegExp(r'\s*#\s.*$'), '');
-      rtnStr += '\n';
+      rtnStr += Platform.isWindows ? '\r\n' : '\n';
     }
     return rtnStr;
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   logging: ^1.2.0
   petitparser: ^6.0.2
   uuid: ^4.4.1
+  universal_io: ^2.2.2
 
 dev_dependencies:
   lints: ^2.0.1

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   http: ^1.2.2
   logging: ^1.2.0
   petitparser: ^6.0.2
-  uuid: ^4.4.2
+  uuid: ^4.4.1
 
 dev_dependencies:
   lints: ^2.0.1


### PR DESCRIPTION
Handle with test file:

```
@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@prefix show: <http://example.org/vocab/show/> .
@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .

show:218 rdfs:label "That Seventies Show"^^xsd:string .            
show:218 rdfs:label "That Seventies Show"^^<http://www.w3.org/2001/XMLSchema#string> . 
show:218 rdfs:label "That Seventies Show" .                                           
show:218 show:localName "That Seventies Show"@en .                 
show:218 show:localName 'Cette Série des Années Soixante-dix'@fr . 
show:218 show:localName "Cette Série des Années Septante"@fr-be .  
show:218 show:blurb '''This is a multi-line
literal with many quotes (""""")
and up to two sequential apostrophes ('').'''^^xsd:string .
```

And in parse result, `(""""")` is convert to `([\, "][\, "][\, "][\, "][\, "])` to avoid parse exception (petitparser seems to only accent one pair of `"` in one literal).